### PR TITLE
add fullPath to file objects so consumers can parse directories

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,6 +78,7 @@ function processEntry (entry, cb) {
 
   if (entry.isFile) {
     entry.file(function (file) {
+      file.fullPath = entry.fullPath  // preserve pathing for consumer
       cb(null, file)
     })
   } else if (entry.isDirectory) {


### PR DESCRIPTION
I wanted to be able to drag and drop folders using this lib, this puts the fullPath field from the entry object onto the file objects that get returned to the consumer allowing us to figure out the directory structure. 

If theres a better way to do this, let me know.