### PR TITLE
drag-leave: handle if elem is parent of e.target

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,11 @@ function makeOnDragOver (elem) {
 
 function makeOnDragLeave (elem) {
   return function (e) {
-    if (e.target !== elem) return
+    if (e.target !== elem) {
+      var parent = e.target
+      while (parent !== elem) parent = parent.parentNode
+      if (!parent) return
+    }
     e.stopPropagation()
     e.preventDefault()
     if (elem instanceof window.Element) elem.classList.remove('drag')


### PR DESCRIPTION
When I was testing the "drag" class wasn't always removed.

This happened when e.target in `makeOnDragLeave` was a child of elem.