### PR TITLE
Use RawGit to serve dragdrop.min.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is an attempt to make the API usable by mere mortals.
 This module works in the browser with [browserify](http://browserify.org/).
 
 **Note:** If you do not use browserify, use the included standalone file
-`dragdrop.min.js`. This exports a `DragDrop` function on `window`.
+[`dragdrop.min.js`](https://rawgit.com/feross/drag-drop/master/dragdrop.min.js). This exports a `DragDrop` function on `window`.
 
 ### live demo
 


### PR DESCRIPTION
Use RawGit (https://rawgit.com), a free service based on MaxCDN's (https://maxcdn.com) super fast global CDN, to serve dragdrop.min.js file directly from GitHub with proper Content-Type header.