### PR TITLE
Replace deprecated dependency flat with array.prototype.flat

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 module.exports = dragDrop
 
-var flatten = require('flatten')
+var flat = require('array.prototype.flat')
 var parallel = require('run-parallel')
 
 function dragDrop (elem, listeners) {
@@ -134,7 +134,7 @@ function dragDrop (elem, listeners) {
         // throw in production code, so the user does not need to use try-catch.
         if (err) throw err
 
-        var entries = flatten(results)
+        var entries = flat(results)
 
         var files = entries.filter(function (item) {
           return item.isFile

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "url": "https://github.com/feross/drag-drop/issues"
   },
   "dependencies": {
+    "array.prototype.flat": "^1.2.1",
     "blob-to-buffer": "^1.0.2",
-    "flatten": "^1.0.2",
     "run-parallel": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Replace [flatten](https://www.npmjs.com/package/flatten) with [array.prototype.flat](https://www.npmjs.com/package/array.prototype.flat).