### PR TITLE
Return entries with depth >1

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,7 +133,7 @@ function dragDrop (elem, listeners) {
         // throw in production code, so the user does not need to use try-catch.
         if (err) throw err
 
-        const entries = results.flat()
+        const entries = results.flat(Infinity)
 
         const files = entries.filter(item => {
           return item.isFile


### PR DESCRIPTION
Dropping a folder will currently not properly return any entries with depth >1 since the array is not being correctly flattened.

`Array.flat()` defaults to a depth of 1.