### PR TITLE
Support text/uri-list MIME type for onDropText

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 example/drag-drop.js
+node_modules/

--- a/index.js
+++ b/index.js
@@ -141,7 +141,7 @@ function dragDrop (elem, listeners) {
     }
 
     // text drop support
-    const text = event.dataTransfer.getData('text')
+    const text = event.dataTransfer.getData('text') || event.dataTransfer.getData('text/uri-list')
     if (text && listeners.onDropText) {
       listeners.onDropText(text, pos)
     }


### PR DESCRIPTION
This allows for drag-and-dropping links contained in HTML anchor elements, if there's no `text` data available.

Rationale: if using `drag-drop` in a place where URLs are expected, it's very convenient for dropping links to work not only with outright strings, but also with anchor tags which are common on websites – something like: `<a href="https://example.com"><img src="bar"></a>`. In this case `.getData('text')` is empty BUT `.getData('text/uri-list')` does have useful data – `'https://example.com'` – and we should make use of this data.

Before, the user could only right-click, click "Copy link address", and somehow use that copied text in the target app. With this tiny change to `drag-drop`, the user can simply drag the anchor element to the target app – and that's it. Significant improvement to the user experience.

Please do release new version if this is merged.