### PR TITLE
Fixed error on draggable HTMLElements

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ function dragDrop (elem, listeners) {
   }
 
   function isEventHandleable (event) {
-    if (event.dataTransfer.items || event.dataTransfer.types) {
+    if (event.dataTransfer.items.length || event.dataTransfer.types.length) {
       // Only add "drag" class when `items` contains items that are able to be
       // handled by the registered listeners (files vs. text)
       const items = Array.from(event.dataTransfer.items)
@@ -59,6 +59,8 @@ function dragDrop (elem, listeners) {
       if (fileItems.length === 0 && !listeners.onDropText) return false
       if (textItems.length === 0 && !listeners.onDrop) return false
       if (fileItems.length === 0 && textItems.length === 0) return false
+    } else {
+      return false
     }
     return true
   }


### PR DESCRIPTION
Hello. I was having some errors when dragging any [draggable](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/draggable) HTMLElement over the "#dropTarget" (see image).
These elements had no dataTransfer.items,  dataTransfer.files or dataTransfer.types, so they were crashing the `isEventHandleable` function.
Hope it's useful, thanks!

![drag-drop](https://user-images.githubusercontent.com/34213485/117179499-8e18cb80-ada9-11eb-8414-901c02f58479.PNG)
